### PR TITLE
Modify Broken Discord Logo URL

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -108,7 +108,7 @@
         <div class="logoContainer"><img class="logo"
                                         src="https://seeklogo.com/images/D/discord-logo-134E148657-seeklogo.com.png"/><img
                 class="text"
-                src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Discord_Color_Text_Logo.svg/2000px-Discord_Color_Text_Logo.svg.png"/>
+                src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e3/Discord_White_Text_Logo_%282015-2021%29.svg/2560px-Discord_White_Text_Logo_%282015-2021%29.svg.png"/>
         </div>
         <div class="acceptContainer">
             <form>


### PR DESCRIPTION
# Fix Discord Logo in Front-end

Modified the URL to the white discord text logo to a new link. *The new link is open-source and without copyright*.

### Before:
![image](https://user-images.githubusercontent.com/50504050/135002023-cf25e59b-3b48-481f-b976-accf265318ef.png)

---

### After:
![image](https://user-images.githubusercontent.com/50504050/135002059-502c25b3-1fef-4ead-addb-fd61b768b3f6.png)
